### PR TITLE
Add scaling strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ This repository contains a Helm chart for deploying a JupyterHub Node Placeholde
 
 The Node Placeholder service works by monitoring the academic calendar events from a provided iCal URL. Based on the events, it dynamically adjusts the number of placeholder nodes available in the Kubernetes cluster, allowing JupyterHub to pre-allocate resources for anticipated user logins. If there are existing user nodes deployed, and these have the capacity to handle additional users, the Node Placeholder service will scale down the number of placeholder nodes accordingly.
 
+:::{admonition} Be careful with time zones!
+:class: warning
+Be sure that the time zone of your public calendar matches the time zone set in the Helm chart values (`calendarTimezone`)!
+:::
+
 If any existing nodes are underutilized, the Node Placeholder service will also scale down the number of placeholder nodes to free up resources. Currently, it will not scale up a new placeholder node if any existing user nodes have > 20% of both CPU and RAM available. This is customizable in the the helm chart values (`values.yaml`).
 
 The events are fetched from the iCal URL and parsed to determine peak usage times, such as the start of exam periods or other significant academic events where you expect a large number of users to log in. The service then scales the number of placeholder nodes accordingly, ensuring that users have a seamless experience when logging into JupyterHub during these high-demand periods.
@@ -38,6 +43,8 @@ An example configuration in `values.yaml` might look like this:
 calendarUrl: https://url.to/your/public/calendar.ics
 
 calendarTimezone: "America/Los_Angeles"
+
+scalingStrategy: mem  # Options: cpu, mem, balanced
 
 nodePools:
   # The short name of the node pool, used in the calendar event description.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ calendarUrl: https://url.to/your/public/calendar.ics
 
 calendarTimezone: "America/Los_Angeles"
 
-scalingStrategy: mem  # Options: cpu, mem, balanced
+scalingStrategy: mem  # Options: cpu, mem, balanced (default)
 
 nodePools:
   # The short name of the node pool, used in the calendar event description.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,8 @@ This repository contains a Helm chart for deploying a JupyterHub Node Placeholde
 
 The Node Placeholder service works by monitoring the academic calendar events from a provided iCal URL. Based on the events, it dynamically adjusts the number of placeholder nodes available in the Kubernetes cluster, allowing JupyterHub to pre-allocate resources for anticipated user logins. If there are existing user nodes deployed, and these have the capacity to handle additional users, the Node Placeholder service will scale down the number of placeholder nodes accordingly.
 
-:::{admonition} Be careful with time zones!
-:class: warning
-Be sure that the time zone of your public calendar matches the time zone set in the Helm chart values (`calendarTimezone`)!
-:::
+> [!NOTE]
+> Be sure that the time zone of your public calendar matches the time zone set in the Helm chart values (`calendarTimezone`)!  Kubernetes itself runs in UTC time, but the Node Placeholder service needs to interpret the calendar events in the correct time zone to function properly.
 
 If any existing nodes are underutilized, the Node Placeholder service will also scale down the number of placeholder nodes to free up resources. Currently, it will not scale up a new placeholder node if any existing user nodes have > 20% of both CPU and RAM available. This is customizable in the the helm chart values (`values.yaml`).
 

--- a/helm/node-placeholder/templates/deployment.yaml
+++ b/helm/node-placeholder/templates/deployment.yaml
@@ -43,6 +43,7 @@ spec:
             - --placeholder-pod-label-selector={{ .Values.placeholderPodLabelSelector }}
             - --cpu-threshold={{ .Values.cpuThreshold }}
             - --memory-threshold={{ .Values.memoryThreshold }}
+            - --strategy={{ .Values.scalingStrategy | default "balanced" }}
           env:
             - name: TZ
               value: {{ .Values.calendarTimezone | default "UTC" }}

--- a/helm/node-placeholder/values.yaml
+++ b/helm/node-placeholder/values.yaml
@@ -49,6 +49,12 @@ priorityClass:
 
 tolerations:
 
+nodePoolSelectorKey: hub.jupyter.org/pool-name
+placeholderPodLabelSelector: "app=node-placeholder-scaler,component=placeholder"
+cpuThreshold: 0.2
+memoryThreshold: 0.2
+scalingStrategy: balanced # Options: cpu, mem, balanced (default)
+
 # The URL of the public calendar to use for the node placeholder.
 # calendarUrl:
 #   https://url/of/the/public/calendar.ics
@@ -117,9 +123,3 @@ tolerations:
 #           # This is an example using a GCP n2-highmem-8 node with 64G of RAM allocatable
 #           memory: 60929654784
 #       replicas: 0
-
-nodePoolSelectorKey: hub.jupyter.org/pool-name
-placeholderPodLabelSelector: "app=node-placeholder-scaler,component=placeholder"
-cpuThreshold: 0.2
-memoryThreshold: 0.2
-scalingStrategy: balanced # Options: cpu, mem, balanced (default)

--- a/helm/node-placeholder/values.yaml
+++ b/helm/node-placeholder/values.yaml
@@ -122,3 +122,4 @@ nodePoolSelectorKey: hub.jupyter.org/pool-name
 placeholderPodLabelSelector: "app=node-placeholder-scaler,component=placeholder"
 cpuThreshold: 0.2
 memoryThreshold: 0.2
+scalingStrategy: balanced

--- a/helm/node-placeholder/values.yaml
+++ b/helm/node-placeholder/values.yaml
@@ -122,4 +122,4 @@ nodePoolSelectorKey: hub.jupyter.org/pool-name
 placeholderPodLabelSelector: "app=node-placeholder-scaler,component=placeholder"
 cpuThreshold: 0.2
 memoryThreshold: 0.2
-scalingStrategy: balanced
+scalingStrategy: balanced # Options: cpu, mem, balanced (default)

--- a/node-placeholder-scaler/scaler/scaler.py
+++ b/node-placeholder-scaler/scaler/scaler.py
@@ -251,6 +251,9 @@ def main():
     )
     argparser.add_argument("--cpu-threshold", type=float, default=0.2)
     argparser.add_argument("--memory-threshold", type=float, default=0.2)
+    argparser.add_argument(
+        "--strategy", choices=["cpu", "mem", "balanced"], default="balanced"
+    )
 
     args = argparser.parse_args()
 
@@ -259,6 +262,7 @@ def main():
     node_selector_key = args.node_pool_selector_key
     cpu_threshold = args.cpu_threshold
     memory_threshold = args.memory_threshold
+    strategy = args.strategy
 
     while True:
         usable_resources_result = get_usable_resources()
@@ -298,11 +302,18 @@ def main():
                         cpu_free_ratio = resources["cpu_free_ratio"]
                         mem_free_ratio = resources["mem_free_ratio"]
                         if (
-                            cpu_free_ratio > cpu_threshold
-                            and mem_free_ratio > memory_threshold
+                            (strategy == "cpu" and cpu_free_ratio > cpu_threshold)
+                            or (strategy == "mem" and mem_free_ratio > memory_threshold)
+                            or (
+                                strategy == "balanced"
+                                and (
+                                    cpu_free_ratio > cpu_threshold
+                                    and mem_free_ratio > memory_threshold
+                                )
+                            )
                         ):
                             logging.info(
-                                f"Node {node} has sufficient resources (CPU free ratio: {cpu_free_ratio}, Memory free ratio: {mem_free_ratio})."
+                                f"Node {node} has sufficient resources (Strategy: {strategy}, CPU free ratio: {cpu_free_ratio}, Memory free ratio: {mem_free_ratio})."
                             )
                             node_placeholder_deployment_reduction += 1
                     else:


### PR DESCRIPTION
this will let folks choose to use `balanced` (default), `cpu` or `mem` based scaling strategies.

when the `--strategy` arg is set to either `mem` and `cpu`, the scaler will ignore the other resources when decided to reduce the number of placeholder pods.

if it's `balanced`, then the scaler will reduce that number of if either resource (`mem` or `cpu`) is greater than the threshold.  i made this setting be the default, and the behavior is as it's been since @yijunge-ucb 's PR (https://github.com/berkeley-dsep-infra/jupyterhub-k8s-node-placeholder/pull/8)