### PR TITLE
fix placeholder label in memory tool, exclude tools/ from build workflow

### DIFF
--- a/.github/workflows/build-publish-node-placeholder.yaml
+++ b/.github/workflows/build-publish-node-placeholder.yaml
@@ -13,6 +13,7 @@ on:
       - '.github/**'
       - '.gitignore'
       - '**/tests/**'
+      - 'tools/**'
     tags:
       - '**'
 

--- a/tools/determine_placeholder_pod_memory.py
+++ b/tools/determine_placeholder_pod_memory.py
@@ -51,7 +51,7 @@ def main():
 
     # determine total memory requests of all non-placeholder, non-notebook pods on the node
     pods = v1.list_pod_for_all_namespaces(
-        label_selector="component!=user-placeholder",
+        label_selector="component!=placeholder",
         field_selector=f"spec.nodeName={node}",
     )
 


### PR DESCRIPTION
## Summary

Two small fixes:

### `tools/determine_placeholder_pod_memory.py`
The label selector was using `component!=user-placeholder`, which is the upstream z2jh label for placeholder pods. This project labels placeholder pods as `component=placeholder`. If the script is run on a node that already has one of this project's placeholder pods running, that pod's memory request would not be excluded from the calculation, producing an incorrectly small `pod_size` value.

Changed to `component!=placeholder` to match the actual pod labels used here.

### `.github/workflows/build-publish-node-placeholder.yaml`
Added `tools/**` to `paths-ignore` so changes to scripts in `tools/` don't trigger unnecessary Docker image builds and Helm chart publishes.

Generated with [Claude Code](https://claude.com/claude-code)