### PR TITLE
fix scaler race condition via pending placeholder pod detection

### DIFF
--- a/helm/node-placeholder/Chart.yaml
+++ b/helm/node-placeholder/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: node-placeholder-scaler
 description: A Helm chart for the JupyterHub Node Placeholder Calendar Scaler
 type: application
-version: 0.0.1-0.dev.git.400.hdbe1c2e
+version: 0.0.1-0.dev.git.424.h1c64a4b
 appVersion: "1.16.0"

--- a/helm/node-placeholder/Chart.yaml
+++ b/helm/node-placeholder/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: node-placeholder-scaler
 description: A Helm chart for the JupyterHub Node Placeholder Calendar Scaler
 type: application
-version: 0.0.1-0.dev.git.424.h1c64a4b
+version: 0.0.1-0.dev.git.428.h3138c2b
 appVersion: "1.16.0"

--- a/helm/node-placeholder/templates/deployment.yaml
+++ b/helm/node-placeholder/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
             - --cpu-threshold={{ .Values.cpuThreshold }}
             - --memory-threshold={{ .Values.memoryThreshold }}
             - --strategy={{ .Values.scalingStrategy | default "balanced" }}
-            - --node-grace-period={{ .Values.nodeGracePeriod }}
+            - --node-grace-period={{ .Values.nodeGracePeriod | default "600" }}
           env:
             - name: TZ
               value: {{ .Values.calendarTimezone | default "UTC" }}

--- a/helm/node-placeholder/templates/deployment.yaml
+++ b/helm/node-placeholder/templates/deployment.yaml
@@ -44,6 +44,7 @@ spec:
             - --cpu-threshold={{ .Values.cpuThreshold }}
             - --memory-threshold={{ .Values.memoryThreshold }}
             - --strategy={{ .Values.scalingStrategy | default "balanced" }}
+            - --node-grace-period={{ .Values.nodeGracePeriod }}
           env:
             - name: TZ
               value: {{ .Values.calendarTimezone | default "UTC" }}

--- a/helm/node-placeholder/values.yaml
+++ b/helm/node-placeholder/values.yaml
@@ -5,7 +5,7 @@ image:
     us-central1-docker.pkg.dev/cal-icor-hubs/core/node-placeholder-scaler
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.0.1-0.dev.git.424.h1c64a4b"
+  tag: "0.0.1-0.dev.git.428.h3138c2b"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm/node-placeholder/values.yaml
+++ b/helm/node-placeholder/values.yaml
@@ -5,7 +5,7 @@ image:
     us-central1-docker.pkg.dev/cal-icor-hubs/core/node-placeholder-scaler
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.0.1-0.dev.git.400.hdbe1c2e"
+  tag: "0.0.1-0.dev.git.424.h1c64a4b"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -54,7 +54,8 @@ placeholderPodLabelSelector: "app=node-placeholder-scaler,component=placeholder"
 cpuThreshold: 0.2
 memoryThreshold: 0.2
 scalingStrategy: balanced # Options: cpu, mem, balanced (default)
-calendarOverrideEnabled: False # Set to True to force the scaler to use calendar replica counts instead of config replica counts when calendar replica counts are greater than 0
+calendarOverrideEnabled: false # Set to True to force the scaler to use calendar replica counts instead of config replica counts when calendar replica counts are greater than 0
+nodeGracePeriod: 600 # seconds a node is protected from placeholder reduction
 
 # The URL of the public calendar to use for the node placeholder.
 # calendarUrl:
@@ -76,10 +77,6 @@ calendarOverrideEnabled: False # Set to True to force the scaler to use calendar
 #     pullPolicy: IfNotPresent
 #     # Overrides the image tag whose default is the chart appVersion.
 #     tag: "tag.of.the.image"
-
-#   # The URL of the public calendar to use for the node placeholder
-#   calendarUrl: 
-#     https://url/of/the/public/calendar.ics
 
 #   nodePools:
 #     <pool-name>:

--- a/node-placeholder-scaler/scaler/calendar_parser.py
+++ b/node-placeholder-scaler/scaler/calendar_parser.py
@@ -89,6 +89,7 @@ def get_events(calendar, time=None):
     # https://stackoverflow.com/questions/753052/strip-html-from-strings-in-python
     events = [x for x in events_iter]
     for ev in events:
-        ev.description = re.sub("<[^<]+?>", "", ev.description)
+        if ev.description:
+            ev.description = re.sub("<[^<]+?>", "", ev.description)
 
     return events

--- a/node-placeholder-scaler/scaler/scaler.py
+++ b/node-placeholder-scaler/scaler/scaler.py
@@ -204,7 +204,7 @@ def any_placeholder_pod_pending(namespace, label_selector, node_selector):
 
 def compute_replica_count(
     modified_replica,
-    config_replica_count,
+    override_replica_count,
     calendar_replica_count,
     calendar_override_enabled,
     has_pending_placeholder=False,
@@ -212,13 +212,17 @@ def compute_replica_count(
     """Return the target placeholder replica count for a pool.
 
     Calendar override takes priority. If a placeholder pod is Pending (evicted
-    but not yet rescheduled), suppress reduction so the deployment isn't scaled
-    down during the window before the pod finds a new home.
+    but not yet rescheduled), suppress reduction and fall back to
+    override_replica_count, the same pre-reduction baseline used to compute
+    modified_replica (replica_count_overrides.get(pool_name, pool_config["replicas"])),
+    so the deployment isn't scaled down during the window before the pod finds
+    a new home, and any calendar-provided count is preserved even when calendar
+    override isn't enabled.
     """
     if calendar_replica_count > 0 and calendar_override_enabled:
         return calendar_replica_count
     elif has_pending_placeholder:
-        return config_replica_count
+        return max(override_replica_count, 0)
     else:
         return max(modified_replica, 0)
 
@@ -386,10 +390,10 @@ def _process_pool(
 
     calendar_replica_count = replica_count_overrides.get(pool_name, 0)
     config_replica_count = pool_config["replicas"]
-    modified_replica = (
-        replica_count_overrides.get(pool_name, pool_config["replicas"])
-        - node_placeholder_deployment_reduction
+    override_replica_count = replica_count_overrides.get(
+        pool_name, pool_config["replicas"]
     )
+    modified_replica = override_replica_count - node_placeholder_deployment_reduction
     has_pending_placeholder = any_placeholder_pod_pending(
         namespace, label_selector, pool_config["nodeSelector"]
     )
@@ -413,7 +417,7 @@ def _process_pool(
 
     replica_count = compute_replica_count(
         modified_replica,
-        config_replica_count,
+        override_replica_count,
         calendar_replica_count,
         calendar_override_enabled,
         has_pending_placeholder,

--- a/node-placeholder-scaler/scaler/scaler.py
+++ b/node-placeholder-scaler/scaler/scaler.py
@@ -284,7 +284,22 @@ def update_node_first_seen(node: str, node_first_seen: dict, now: float) -> floa
     return now - node_first_seen[node]
 
 
+def update_node_last_above_threshold(
+    node: str, node_last_above_threshold: dict, now: float
+) -> None:
+    """Record that a node was seen above the utilization threshold at time `now`.
+
+    Call this whenever a node is hosting a placeholder pod or its utilization
+    is above the configured threshold.  The stored timestamp is used to
+    enforce the recently-freed grace period: a node that drops below the
+    threshold (or loses its placeholder) is not immediately counted for
+    replica reduction.  Mutates node_last_above_threshold in place.
+    """
+    node_last_above_threshold[node] = now
+
+
 def get_replica_counts(events):
+    """Parse calendar events to extract desired replica counts for each pool."""
     replica_counts = {}
     for ev in events:
         logging.info(f"Found event {_event_repr(ev)}")
@@ -345,7 +360,12 @@ def main():
         "--node-grace-period",
         type=int,
         default=300,
-        help="Seconds after node creation during which the node is excluded from placeholder reduction.",
+        help=(
+            "Seconds a node is protected from placeholder reduction: "
+            "(1) after the scaler first observes it (new-node grace period) and "
+            "(2) after it drops below the utilization threshold or loses its "
+            "placeholder pod (recently-freed grace period)."
+        ),
     )
 
     args = argparser.parse_args()
@@ -359,8 +379,12 @@ def main():
     node_grace_period = args.node_grace_period
 
     # Maps node name -> perf_counter value when the scaler first observed it.
-    # Used to enforce the node grace period across loop iterations.
+    # Used to enforce the new-node grace period across loop iterations.
     node_first_seen: dict[str, float] = {}
+    # Maps node name -> perf_counter value when the node was last seen above
+    # the utilization threshold (or hosting a placeholder pod).  Used to
+    # enforce the recently-freed grace period.
+    node_last_above_threshold: dict[str, float] = {}
 
     while True:
         usable_resources_result = get_usable_resources()
@@ -400,45 +424,61 @@ def main():
                     )
                     # Check if the node is unschedulable
                     unschedulable_node = is_unschedulable_node(node)
-                    if not placeholder_pod_running and not unschedulable_node:
+                    if placeholder_pod_running:
+                        # Node hosts the placeholder — mark it above threshold so
+                        # the recently-freed grace period applies if the placeholder
+                        # later moves off (e.g., evicted by a user login).
+                        update_node_last_above_threshold(
+                            node, node_last_above_threshold, now
+                        )
+                        logging.info(
+                            f"Placeholder pod is running on {node}. Skipping resource check for this node."
+                        )
+                    elif unschedulable_node:
+                        logging.info(
+                            f"Node {node} is unschedulable. Skipping resource check for this node."
+                        )
+                    else:
                         node_age_seconds = update_node_first_seen(
                             node, node_first_seen, now
                         )
-                        if node_age_seconds < node_grace_period:
+                        cpu_free_ratio = resources["cpu_free_ratio"]
+                        mem_free_ratio = resources["mem_free_ratio"]
+                        is_free = (
+                            (strategy == "cpu" and cpu_free_ratio > cpu_threshold)
+                            or (strategy == "mem" and mem_free_ratio > memory_threshold)
+                            or (
+                                strategy == "balanced"
+                                and (
+                                    cpu_free_ratio > cpu_threshold
+                                    and mem_free_ratio > memory_threshold
+                                )
+                            )
+                        )
+                        if not is_free:
+                            update_node_last_above_threshold(
+                                node, node_last_above_threshold, now
+                            )
+                        elif node_age_seconds < node_grace_period:
                             logging.info(
                                 f"Node {node} has been observed for {node_age_seconds:.0f}s, "
                                 f"within {node_grace_period}s grace period. Skipping reduction."
                             )
-                        else:
-                            cpu_free_ratio = resources["cpu_free_ratio"]
-                            mem_free_ratio = resources["mem_free_ratio"]
-                            if (
-                                (strategy == "cpu" and cpu_free_ratio > cpu_threshold)
-                                or (
-                                    strategy == "mem"
-                                    and mem_free_ratio > memory_threshold
-                                )
-                                or (
-                                    strategy == "balanced"
-                                    and (
-                                        cpu_free_ratio > cpu_threshold
-                                        and mem_free_ratio > memory_threshold
-                                    )
-                                )
-                            ):
-                                logging.info(
-                                    f"Node {node} has sufficient resources (Strategy: {strategy}, CPU free ratio: {cpu_free_ratio:.2f}, Memory free ratio: {mem_free_ratio:.2f})."
-                                )
-                                node_placeholder_deployment_reduction += 1
-                    else:
-                        if placeholder_pod_running:
+                        elif (
+                            node in node_last_above_threshold
+                            and (now - node_last_above_threshold[node])
+                            < node_grace_period
+                        ):
+                            time_since_freed = now - node_last_above_threshold[node]
                             logging.info(
-                                f"Placeholder pod is running on {node}. Skipping resource check for this node."
+                                f"Node {node} was above threshold {time_since_freed:.0f}s ago, "
+                                f"within {node_grace_period}s recently-freed grace period. Skipping reduction."
                             )
                         else:
                             logging.info(
-                                f"Node {node} is unschedulable. Skipping resource check for this node."
+                                f"Node {node} has sufficient resources (Strategy: {strategy}, CPU free ratio: {cpu_free_ratio:.2f}, Memory free ratio: {mem_free_ratio:.2f})."
                             )
+                            node_placeholder_deployment_reduction += 1
 
                 calendar_replica_count = replica_count_overrides.get(pool_name, 0)
                 config_replica_count = pool_config["replicas"]
@@ -506,7 +546,7 @@ def main():
 
                     logging.info(proc.stdout.strip())
 
-        # Evict first-seen entries for nodes no longer present in the cluster.
+        # Evict tracking entries for nodes no longer present in the cluster.
         all_seen_nodes = {
             node
             for pool_nodes in usable_resources_result.values()
@@ -514,5 +554,8 @@ def main():
         }
         node_first_seen = {
             n: t for n, t in node_first_seen.items() if n in all_seen_nodes
+        }
+        node_last_above_threshold = {
+            n: t for n, t in node_last_above_threshold.items() if n in all_seen_nodes
         }
         time.sleep(60)

--- a/node-placeholder-scaler/scaler/scaler.py
+++ b/node-placeholder-scaler/scaler/scaler.py
@@ -228,10 +228,11 @@ def compute_replica_count(
     down during the window before the pod finds a new home.
     """
     if calendar_replica_count > 0 and calendar_override_enabled:
-        return max(calendar_replica_count, 0)
-    if has_pending_placeholder:
+        return calendar_replica_count
+    elif has_pending_placeholder:
         return config_replica_count
-    return max(modified_replica, 0)
+    else:
+        return max(modified_replica, 0)
 
 
 def is_unschedulable_node(node_name):
@@ -418,7 +419,11 @@ def main():
                 logging.info(
                     f"Pending placeholder pod detected for pool {pool_name}: {has_pending_placeholder}"
                 )
-                if has_pending_placeholder:
+                if calendar_replica_count > 0 and calendar_override_enabled:
+                    logging.info(
+                        f"Overriding replica count for pool {pool_name} with calendar replica count {calendar_replica_count} instead of modified replica count {modified_replica}."
+                    )
+                elif has_pending_placeholder:
                     logging.info(
                         f"Suppressing reduction for pool {pool_name}: placeholder pod is Pending."
                     )

--- a/node-placeholder-scaler/scaler/scaler.py
+++ b/node-placeholder-scaler/scaler/scaler.py
@@ -183,6 +183,57 @@ def placeholder_pod_running_on_node(node_name, namespace, label_selector):
         return False
 
 
+def any_placeholder_pod_pending(namespace, label_selector, node_selector):
+    """Returns True if any placeholder pod for the given pool is Pending.
+
+    Filters by node_selector to avoid suppressing reduction in unrelated pools.
+    """
+    try:
+        config.load_incluster_config()
+    except config.ConfigException:
+        config.load_kube_config()
+
+    v1 = client.CoreV1Api()
+
+    try:
+        pods = v1.list_namespaced_pod(
+            namespace=namespace, label_selector=label_selector
+        ).items
+
+        for pod in pods:
+            if (
+                pod.status.phase == "Pending"
+                and pod.spec.node_selector == node_selector
+            ):
+                return True
+
+        return False
+
+    except client.exceptions.ApiException as e:
+        logging.error(f"Kubernetes API error: {e}")
+        return False
+
+
+def compute_replica_count(
+    modified_replica,
+    config_replica_count,
+    calendar_replica_count,
+    calendar_override_enabled,
+    has_pending_placeholder=False,
+):
+    """Return the target placeholder replica count for a pool.
+
+    Calendar override takes priority. If a placeholder pod is Pending (evicted
+    but not yet rescheduled), suppress reduction so the deployment isn't scaled
+    down during the window before the pod finds a new home.
+    """
+    if calendar_replica_count > 0 and calendar_override_enabled:
+        return max(calendar_replica_count, 0)
+    if has_pending_placeholder:
+        return config_replica_count
+    return max(modified_replica, 0)
+
+
 def is_unschedulable_node(node_name):
     try:
         config.load_incluster_config()
@@ -355,23 +406,33 @@ def main():
                     replica_count_overrides.get(pool_name, pool_config["replicas"])
                     - node_placeholder_deployment_reduction
                 )
+                has_pending_placeholder = any_placeholder_pod_pending(
+                    namespace, label_selector, pool_config["nodeSelector"]
+                )
                 logging.info(
                     f"Calendar replica count for pool {pool_name}: {calendar_replica_count}"
                 )
-
-                if calendar_replica_count > 0 and calendar_override_enabled:
+                logging.info(
+                    f"Config replica count for pool {pool_name}: {config_replica_count}"
+                )
+                logging.info(
+                    f"Pending placeholder pod detected for pool {pool_name}: {has_pending_placeholder}"
+                )
+                if has_pending_placeholder:
                     logging.info(
-                        f"Overriding config replica count for pool {pool_name} with calendar replica count {calendar_replica_count} instead of modified replica count: {modified_replica}."
+                        f"Suppressing reduction for pool {pool_name}: placeholder pod is Pending."
                     )
-                    replica_count = max(calendar_replica_count, 0)
                 else:
-                    logging.info(
-                        f"Config replica count for pool {pool_name}: {config_replica_count}"
-                    )
                     logging.info(
                         f"Reducing {pool_name} placeholder deployment replicas by {node_placeholder_deployment_reduction} based on node resources."
                     )
-                    replica_count = max(modified_replica, 0)
+                replica_count = compute_replica_count(
+                    modified_replica,
+                    config_replica_count,
+                    calendar_replica_count,
+                    calendar_override_enabled,
+                    has_pending_placeholder,
+                )
                 logging.info(
                     f"Final replica count for pool {pool_name}: {replica_count}"
                 )

--- a/node-placeholder-scaler/scaler/scaler.py
+++ b/node-placeholder-scaler/scaler/scaler.py
@@ -396,9 +396,14 @@ def main():
                             )
                             node_placeholder_deployment_reduction += 1
                     else:
-                        logging.info(
-                            f"Placeholder pod is running or {node} is unschedulable. Skipping resource check for this node."
-                        )
+                        if placeholder_pod_running:
+                            logging.info(
+                                f"Placeholder pod is running on {node}. Skipping resource check for this node."
+                            )
+                        else:
+                            logging.info(
+                                f"Node {node} is unschedulable. Skipping resource check for this node."
+                            )
 
                 calendar_replica_count = replica_count_overrides.get(pool_name, 0)
                 config_replica_count = pool_config["replicas"]

--- a/node-placeholder-scaler/scaler/scaler.py
+++ b/node-placeholder-scaler/scaler/scaler.py
@@ -464,7 +464,7 @@ def main():
     argparser.add_argument(
         "--node-grace-period",
         type=int,
-        default=300,
+        default=600,
         help=(
             "Seconds a node is protected from placeholder reduction: "
             "(1) after the scaler first observes it (new-node grace period) and "

--- a/node-placeholder-scaler/scaler/scaler.py
+++ b/node-placeholder-scaler/scaler/scaler.py
@@ -138,18 +138,22 @@ def get_usable_resources():
             if node not in usable_resources_result[pool]:
                 usable_resources_result[pool][node] = {}
 
-            requested = requested_resources.get(pool).get(node)
-            free_cpu = node_info["cpu_m"] - requested["cpu_m"]
-            free_mem = node_info["mem_mi"] - requested["mem_mi"]
+            requested = requested_resources.get(pool, {}).get(
+                node, {"cpu_m": 0, "mem_mi": 0}
+            )
+            cpu_alloc = node_info["cpu_m"]
+            mem_alloc = node_info["mem_mi"]
+            free_cpu = cpu_alloc - requested["cpu_m"]
+            free_mem = mem_alloc - requested["mem_mi"]
             usable_resources_result[pool][node] = {
-                "cpu_alloc_m": node_info["cpu_m"],
+                "cpu_alloc_m": cpu_alloc,
                 "cpu_requested_m": requested["cpu_m"],
                 "cpu_free_m": free_cpu,
-                "cpu_free_ratio": float(free_cpu) / node_info["cpu_m"],
-                "mem_alloc_mi": node_info["mem_mi"],
+                "cpu_free_ratio": float(free_cpu) / cpu_alloc if cpu_alloc > 0 else 0.0,
+                "mem_alloc_mi": mem_alloc,
                 "mem_requested_mi": requested["mem_mi"],
                 "mem_free_mi": free_mem,
-                "mem_free_ratio": float(free_mem) / node_info["mem_mi"],
+                "mem_free_ratio": float(free_mem) / mem_alloc if mem_alloc > 0 else 0.0,
                 "node_pool": pool,
             }
 

--- a/node-placeholder-scaler/scaler/scaler.py
+++ b/node-placeholder-scaler/scaler/scaler.py
@@ -16,13 +16,18 @@ yaml = YAML(typ="safe")
 log = logging.getLogger(__name__)
 
 
-def get_node_pool_mapping(label_key="hub.jupyter.org/pool-name"):
-    """Returns a mapping from node name to node pool label."""
+def _get_v1_client() -> client.CoreV1Api:
+    """Load kube config and return a CoreV1Api instance."""
     try:
         config.load_incluster_config()
     except config.ConfigException:
         config.load_kube_config()
-    v1 = client.CoreV1Api()
+    return client.CoreV1Api()
+
+
+def get_node_pool_mapping(label_key="hub.jupyter.org/pool-name"):
+    """Returns a mapping from node name to node pool label."""
+    v1 = _get_v1_client()
     nodes = v1.list_node().items
 
     node_to_pool = {}
@@ -37,13 +42,7 @@ def get_node_pool_mapping(label_key="hub.jupyter.org/pool-name"):
 
 def get_allocatable_resources_by_pool(node_to_pool_dict):
     """Returns dict: {pool: {node: {'cpu_m': int, 'mem_mi': int}}} with allocatable resources."""
-
-    try:
-        config.load_incluster_config()
-    except config.ConfigException:
-        config.load_kube_config()
-
-    v1 = client.CoreV1Api()
+    v1 = _get_v1_client()
 
     pool_resources = {}
     nodes = v1.list_node().items
@@ -80,13 +79,7 @@ def get_allocatable_resources_by_pool(node_to_pool_dict):
 
 def get_requested_resources_by_pool(node_to_pool_dict):
     """Returns dict: {pool: {node: {'cpu_m': int, 'mem_mi': int}}} with requested resources."""
-
-    try:
-        config.load_incluster_config()
-    except config.ConfigException:
-        config.load_kube_config()
-
-    v1 = client.CoreV1Api()
+    v1 = _get_v1_client()
     pods = v1.list_pod_for_all_namespaces().items
 
     pool_resources = {}
@@ -162,12 +155,7 @@ def get_usable_resources():
 
 
 def placeholder_pod_running_on_node(node_name, namespace, label_selector):
-    try:
-        config.load_incluster_config()
-    except config.ConfigException:
-        config.load_kube_config()
-
-    v1 = client.CoreV1Api()
+    v1 = _get_v1_client()
 
     try:
         pods = v1.list_namespaced_pod(
@@ -193,12 +181,7 @@ def any_placeholder_pod_pending(namespace, label_selector, node_selector):
 
     Filters by node_selector to avoid suppressing reduction in unrelated pools.
     """
-    try:
-        config.load_incluster_config()
-    except config.ConfigException:
-        config.load_kube_config()
-
-    v1 = client.CoreV1Api()
+    v1 = _get_v1_client()
 
     try:
         pods = v1.list_namespaced_pod(
@@ -241,19 +224,11 @@ def compute_replica_count(
 
 
 def is_unschedulable_node(node_name):
-    try:
-        config.load_incluster_config()
-    except config.ConfigException:
-        config.load_kube_config()
-
-    v1 = client.CoreV1Api()
+    v1 = _get_v1_client()
 
     try:
         node = v1.read_node(name=node_name)
-        unschedulable = node.spec.unschedulable
-        if unschedulable:
-            return True
-        return False
+        return bool(node.spec.unschedulable)
 
     except client.exceptions.ApiException as e:
         log.error(f"Kubernetes API error: {e}")
@@ -302,7 +277,6 @@ def get_replica_counts(events):
     for ev in events:
         log.info(f"Found event {_event_repr(ev)}")
         if ev.description:
-            # initialize
             pools_replica_config = None
             try:
                 pools_replica_config = yaml.load(ev.description)
@@ -310,7 +284,6 @@ def get_replica_counts(events):
                 log.error(f"Caught unhandled exception parsing event description:\n{e}")
                 log.error(f"Error in parsing description of {_event_repr(ev)}")
                 log.error(f"{ev.description=}")
-                pass
             if pools_replica_config is None:
                 log.error(f"No description in event {_event_repr(ev)}")
                 continue
@@ -329,6 +302,142 @@ def get_replica_counts(events):
         else:
             log.error(f"Event has no description: {_event_repr(ev)}")
     return replica_counts
+
+
+def _process_pool(
+    pool_name,
+    pool_config,
+    pool_usable_resources,
+    replica_count_overrides,
+    calendar_override_enabled,
+    placeholder_template,
+    namespace,
+    label_selector,
+    strategy,
+    cpu_threshold,
+    memory_threshold,
+    node_grace_period,
+    node_first_seen,
+    node_last_above_threshold,
+):
+    """Compute and apply the placeholder deployment replica count for one pool."""
+    log.info(f"Processing the node pool: {pool_name} ... ")
+    node_placeholder_deployment_reduction = 0
+    now = time.perf_counter()
+
+    for node, resources in pool_usable_resources.items():
+        log.info(f"Checking node {node} in pool {pool_name} ...")
+        log.info(
+            f"Node {node} has {resources['cpu_free_ratio']:.2f} CPU free ratio and {resources['mem_free_ratio']:.2f} Memory free ratio."
+        )
+        placeholder_pod_running = placeholder_pod_running_on_node(
+            node, namespace, label_selector
+        )
+        unschedulable_node = is_unschedulable_node(node)
+
+        if placeholder_pod_running:
+            # Node hosts the placeholder — mark it above threshold so
+            # the recently-freed grace period applies if the placeholder
+            # later moves off (e.g., evicted by a user login).
+            update_node_last_above_threshold(node, node_last_above_threshold, now)
+            log.info(
+                f"Placeholder pod is running on {node}. Skipping resource check for this node."
+            )
+        elif unschedulable_node:
+            log.info(
+                f"Node {node} is unschedulable. Skipping resource check for this node."
+            )
+        else:
+            node_age_seconds = update_node_first_seen(node, node_first_seen, now)
+            cpu_free_ratio = resources["cpu_free_ratio"]
+            mem_free_ratio = resources["mem_free_ratio"]
+            is_free = (
+                (strategy == "cpu" and cpu_free_ratio > cpu_threshold)
+                or (strategy == "mem" and mem_free_ratio > memory_threshold)
+                or (
+                    strategy == "balanced"
+                    and (
+                        cpu_free_ratio > cpu_threshold
+                        and mem_free_ratio > memory_threshold
+                    )
+                )
+            )
+            if not is_free:
+                update_node_last_above_threshold(node, node_last_above_threshold, now)
+            elif node_age_seconds < node_grace_period:
+                log.info(
+                    f"Node {node} has been observed for {node_age_seconds:.0f}s, "
+                    f"within {node_grace_period}s grace period. Skipping reduction."
+                )
+            elif (
+                node in node_last_above_threshold
+                and (now - node_last_above_threshold[node]) < node_grace_period
+            ):
+                time_since_freed = now - node_last_above_threshold[node]
+                log.info(
+                    f"Node {node} was above threshold {time_since_freed:.0f}s ago, "
+                    f"within {node_grace_period}s recently-freed grace period. Skipping reduction."
+                )
+            else:
+                log.info(
+                    f"Node {node} has sufficient resources (Strategy: {strategy}, CPU free ratio: {cpu_free_ratio:.2f}, Memory free ratio: {mem_free_ratio:.2f})."
+                )
+                node_placeholder_deployment_reduction += 1
+
+    calendar_replica_count = replica_count_overrides.get(pool_name, 0)
+    config_replica_count = pool_config["replicas"]
+    modified_replica = (
+        replica_count_overrides.get(pool_name, pool_config["replicas"])
+        - node_placeholder_deployment_reduction
+    )
+    has_pending_placeholder = any_placeholder_pod_pending(
+        namespace, label_selector, pool_config["nodeSelector"]
+    )
+    log.info(f"Calendar replica count for pool {pool_name}: {calendar_replica_count}")
+    log.info(f"Config replica count for pool {pool_name}: {config_replica_count}")
+    log.info(
+        f"Pending placeholder pod detected for pool {pool_name}: {has_pending_placeholder}"
+    )
+    if calendar_replica_count > 0 and calendar_override_enabled:
+        log.info(
+            f"Overriding replica count for pool {pool_name} with calendar replica count {calendar_replica_count} instead of modified replica count {modified_replica}."
+        )
+    elif has_pending_placeholder:
+        log.info(
+            f"Suppressing reduction for pool {pool_name}: placeholder pod is Pending."
+        )
+    else:
+        log.info(
+            f"Reducing {pool_name} placeholder deployment replicas by {node_placeholder_deployment_reduction} based on node resources."
+        )
+
+    replica_count = compute_replica_count(
+        modified_replica,
+        config_replica_count,
+        calendar_replica_count,
+        calendar_override_enabled,
+        has_pending_placeholder,
+    )
+    log.info(f"Final replica count for pool {pool_name}: {replica_count}")
+
+    deployment = make_deployment(
+        pool_name,
+        placeholder_template,
+        pool_config["nodeSelector"],
+        pool_config["resources"],
+        replica_count,
+    )
+    log.info(f"Setting {pool_name} to have {replica_count} replicas")
+    with tempfile.NamedTemporaryFile(mode="r+") as f:
+        yaml.dump(deployment, f)
+        f.flush()
+        proc = subprocess.run(
+            ["kubectl", "apply", "-f", f.name],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        log.info(proc.stdout.strip())
 
 
 def main():
@@ -387,158 +496,46 @@ def main():
         # Reload all config files on each iteration, so we can change config
         # without needing to bounce the pod
         with open(args.config_file) as f:
-            config = yaml.load(f)
+            cfg = yaml.load(f)
 
         with open(args.placeholder_template_file) as f:
             placeholder_template = yaml.load(f)
 
-        calendar = get_calendar(config["calendarUrl"])
+        calendar = get_calendar(cfg["calendarUrl"])
 
         if calendar:
             events = get_events(calendar)
-            log.info(f"Found {len(events)} events at {config['calendarUrl']}.")
+            log.info(f"Found {len(events)} events at {cfg['calendarUrl']}.")
 
             replica_count_overrides = get_replica_counts(events)
             log.info(f"Overrides: {replica_count_overrides}")
 
-            # Generate deployment config based on our config
-            for pool_name, pool_config in config["nodePools"].items():
+            calendar_override_enabled = cfg.get("calendarOverrideEnabled", False)
+            if not isinstance(calendar_override_enabled, bool):
+                raise ValueError(
+                    f"calendarOverrideEnabled must be a boolean, got {type(calendar_override_enabled).__name__}: {calendar_override_enabled!r}"
+                )
+
+            for pool_name, pool_config in cfg["nodePools"].items():
                 pool_usable_resources = usable_resources_result.get(
                     pool_config["nodeSelector"][node_selector_key], {}
                 )
-                log.info(f"Processing the node pool: {pool_name} ... ")
-                node_placeholder_deployment_reduction = 0
-                now = time.perf_counter()
-                for node, resources in pool_usable_resources.items():
-                    log.info(f"Checking node {node} in pool {pool_name} ...")
-                    log.info(
-                        f"Node {node} has {resources['cpu_free_ratio']:.2f} CPU free ratio and {resources['mem_free_ratio']:.2f} Memory free ratio."
-                    )
-                    # Check if a placeholder pod is running on this node
-                    placeholder_pod_running = placeholder_pod_running_on_node(
-                        node, namespace, label_selector
-                    )
-                    # Check if the node is unschedulable
-                    unschedulable_node = is_unschedulable_node(node)
-                    if placeholder_pod_running:
-                        # Node hosts the placeholder — mark it above threshold so
-                        # the recently-freed grace period applies if the placeholder
-                        # later moves off (e.g., evicted by a user login).
-                        update_node_last_above_threshold(
-                            node, node_last_above_threshold, now
-                        )
-                        log.info(
-                            f"Placeholder pod is running on {node}. Skipping resource check for this node."
-                        )
-                    elif unschedulable_node:
-                        log.info(
-                            f"Node {node} is unschedulable. Skipping resource check for this node."
-                        )
-                    else:
-                        node_age_seconds = update_node_first_seen(
-                            node, node_first_seen, now
-                        )
-                        cpu_free_ratio = resources["cpu_free_ratio"]
-                        mem_free_ratio = resources["mem_free_ratio"]
-                        is_free = (
-                            (strategy == "cpu" and cpu_free_ratio > cpu_threshold)
-                            or (strategy == "mem" and mem_free_ratio > memory_threshold)
-                            or (
-                                strategy == "balanced"
-                                and (
-                                    cpu_free_ratio > cpu_threshold
-                                    and mem_free_ratio > memory_threshold
-                                )
-                            )
-                        )
-                        if not is_free:
-                            update_node_last_above_threshold(
-                                node, node_last_above_threshold, now
-                            )
-                        elif node_age_seconds < node_grace_period:
-                            log.info(
-                                f"Node {node} has been observed for {node_age_seconds:.0f}s, "
-                                f"within {node_grace_period}s grace period. Skipping reduction."
-                            )
-                        elif (
-                            node in node_last_above_threshold
-                            and (now - node_last_above_threshold[node])
-                            < node_grace_period
-                        ):
-                            time_since_freed = now - node_last_above_threshold[node]
-                            log.info(
-                                f"Node {node} was above threshold {time_since_freed:.0f}s ago, "
-                                f"within {node_grace_period}s recently-freed grace period. Skipping reduction."
-                            )
-                        else:
-                            log.info(
-                                f"Node {node} has sufficient resources (Strategy: {strategy}, CPU free ratio: {cpu_free_ratio:.2f}, Memory free ratio: {mem_free_ratio:.2f})."
-                            )
-                            node_placeholder_deployment_reduction += 1
-
-                calendar_replica_count = replica_count_overrides.get(pool_name, 0)
-                config_replica_count = pool_config["replicas"]
-                calendar_override_enabled = config.get("calendarOverrideEnabled", False)
-                if not isinstance(calendar_override_enabled, bool):
-                    raise ValueError(
-                        f"calendarOverrideEnabled must be a boolean, got {type(calendar_override_enabled).__name__}: {calendar_override_enabled!r}"
-                    )
-                modified_replica = (
-                    replica_count_overrides.get(pool_name, pool_config["replicas"])
-                    - node_placeholder_deployment_reduction
+                _process_pool(
+                    pool_name=pool_name,
+                    pool_config=pool_config,
+                    pool_usable_resources=pool_usable_resources,
+                    replica_count_overrides=replica_count_overrides,
+                    calendar_override_enabled=calendar_override_enabled,
+                    placeholder_template=placeholder_template,
+                    namespace=namespace,
+                    label_selector=label_selector,
+                    strategy=strategy,
+                    cpu_threshold=cpu_threshold,
+                    memory_threshold=memory_threshold,
+                    node_grace_period=node_grace_period,
+                    node_first_seen=node_first_seen,
+                    node_last_above_threshold=node_last_above_threshold,
                 )
-                has_pending_placeholder = any_placeholder_pod_pending(
-                    namespace, label_selector, pool_config["nodeSelector"]
-                )
-                log.info(
-                    f"Calendar replica count for pool {pool_name}: {calendar_replica_count}"
-                )
-                log.info(
-                    f"Config replica count for pool {pool_name}: {config_replica_count}"
-                )
-                log.info(
-                    f"Pending placeholder pod detected for pool {pool_name}: {has_pending_placeholder}"
-                )
-                if calendar_replica_count > 0 and calendar_override_enabled:
-                    log.info(
-                        f"Overriding replica count for pool {pool_name} with calendar replica count {calendar_replica_count} instead of modified replica count {modified_replica}."
-                    )
-                elif has_pending_placeholder:
-                    log.info(
-                        f"Suppressing reduction for pool {pool_name}: placeholder pod is Pending."
-                    )
-                else:
-                    log.info(
-                        f"Reducing {pool_name} placeholder deployment replicas by {node_placeholder_deployment_reduction} based on node resources."
-                    )
-                replica_count = compute_replica_count(
-                    modified_replica,
-                    config_replica_count,
-                    calendar_replica_count,
-                    calendar_override_enabled,
-                    has_pending_placeholder,
-                )
-                log.info(f"Final replica count for pool {pool_name}: {replica_count}")
-
-                deployment = make_deployment(
-                    pool_name,
-                    placeholder_template,
-                    pool_config["nodeSelector"],
-                    pool_config["resources"],
-                    replica_count,
-                )
-                log.info(f"Setting {pool_name} to have {replica_count} replicas")
-                with tempfile.NamedTemporaryFile(mode="r+") as f:
-                    yaml.dump(deployment, f)
-                    f.flush()
-                    proc = subprocess.run(
-                        ["kubectl", "apply", "-f", f.name],
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE,
-                        text=True,
-                    )
-
-                    log.info(proc.stdout.strip())
 
         # Evict tracking entries for nodes no longer present in the cluster.
         all_seen_nodes = {

--- a/node-placeholder-scaler/scaler/scaler.py
+++ b/node-placeholder-scaler/scaler/scaler.py
@@ -219,7 +219,7 @@ def compute_replica_count(
     a new home, and any calendar-provided count is preserved even when calendar
     override isn't enabled.
     """
-    if calendar_replica_count > 0 and calendar_override_enabled:
+    if calendar_replica_count is not None and calendar_override_enabled:
         return calendar_replica_count
     elif has_pending_placeholder:
         return max(override_replica_count, 0)
@@ -297,7 +297,12 @@ def get_replica_counts(events):
                 continue
             for pool_name, count in pools_replica_config.items():
                 if not isinstance(count, int):
-                    log.info(f"Count {count} not an integer.")
+                    log.info(f"Count {count} for pool {pool_name} not an integer.")
+                    continue
+                if count < 0:
+                    log.error(
+                        f"Count {count} for pool {pool_name} is negative; skipping."
+                    )
                     continue
                 if pool_name not in replica_counts:
                     replica_counts[pool_name] = count
@@ -388,7 +393,7 @@ def _process_pool(
                 )
                 node_placeholder_deployment_reduction += 1
 
-    calendar_replica_count = replica_count_overrides.get(pool_name, 0)
+    calendar_replica_count = replica_count_overrides.get(pool_name, None)
     config_replica_count = pool_config["replicas"]
     override_replica_count = replica_count_overrides.get(
         pool_name, pool_config["replicas"]
@@ -402,7 +407,7 @@ def _process_pool(
     log.info(
         f"Pending placeholder pod detected for pool {pool_name}: {has_pending_placeholder}"
     )
-    if calendar_replica_count > 0 and calendar_override_enabled:
+    if calendar_replica_count is not None and calendar_override_enabled:
         log.info(
             f"Overriding replica count for pool {pool_name} with calendar replica count {calendar_replica_count} instead of modified replica count {modified_replica}."
         )

--- a/node-placeholder-scaler/scaler/scaler.py
+++ b/node-placeholder-scaler/scaler/scaler.py
@@ -13,6 +13,7 @@ from .calendar_parser import _event_repr, get_calendar, get_events
 from .utils import parse_cpu, parse_memory
 
 yaml = YAML(typ="safe")
+log = logging.getLogger(__name__)
 
 
 def get_node_pool_mapping(label_key="hub.jupyter.org/pool-name"):
@@ -183,7 +184,7 @@ def placeholder_pod_running_on_node(node_name, namespace, label_selector):
         return False
 
     except client.exceptions.ApiException as e:
-        logging.error(f"Kubernetes API error: {e}")
+        log.error(f"Kubernetes API error: {e}")
         return False
 
 
@@ -214,7 +215,7 @@ def any_placeholder_pod_pending(namespace, label_selector, node_selector):
         return False
 
     except client.exceptions.ApiException as e:
-        logging.error(f"Kubernetes API error: {e}")
+        log.error(f"Kubernetes API error: {e}")
         return False
 
 
@@ -255,7 +256,7 @@ def is_unschedulable_node(node_name):
         return False
 
     except client.exceptions.ApiException as e:
-        logging.error(f"Kubernetes API error: {e}")
+        log.error(f"Kubernetes API error: {e}")
         return False
 
 
@@ -268,9 +269,6 @@ def make_deployment(pool_name, template, node_selector, resources, replicas):
     deployment["spec"]["template"]["spec"]["containers"][0]["resources"] = resources
 
     return deployment
-
-
-log = logging.getLogger(__name__)
 
 
 def update_node_first_seen(node: str, node_first_seen: dict, now: float) -> float:
@@ -302,36 +300,34 @@ def get_replica_counts(events):
     """Parse calendar events to extract desired replica counts for each pool."""
     replica_counts = {}
     for ev in events:
-        logging.info(f"Found event {_event_repr(ev)}")
+        log.info(f"Found event {_event_repr(ev)}")
         if ev.description:
             # initialize
             pools_replica_config = None
             try:
                 pools_replica_config = yaml.load(ev.description)
             except Exception as e:
-                logging.error(
-                    f"Caught unhandled exception parsing event description:\n{e}"
-                )
-                logging.error(f"Error in parsing description of {_event_repr(ev)}")
-                logging.error(f"{ev.description=}")
+                log.error(f"Caught unhandled exception parsing event description:\n{e}")
+                log.error(f"Error in parsing description of {_event_repr(ev)}")
+                log.error(f"{ev.description=}")
                 pass
             if pools_replica_config is None:
-                logging.error(f"No description in event {_event_repr(ev)}")
+                log.error(f"No description in event {_event_repr(ev)}")
                 continue
             elif isinstance(pools_replica_config, str):
-                logging.error("Event description not parsed as dictionary.")
-                logging.error(f"{ev.description=}")
+                log.error("Event description not parsed as dictionary.")
+                log.error(f"{ev.description=}")
                 continue
             for pool_name, count in pools_replica_config.items():
                 if not isinstance(count, int):
-                    logging.info(f"Count {count} not an integer.")
+                    log.info(f"Count {count} not an integer.")
                     continue
                 if pool_name not in replica_counts:
                     replica_counts[pool_name] = count
                 else:
                     replica_counts[pool_name] = max(replica_counts[pool_name], count)
         else:
-            logging.error(f"Event has no description: {_event_repr(ev)}")
+            log.error(f"Event has no description: {_event_repr(ev)}")
     return replica_counts
 
 
@@ -400,22 +396,22 @@ def main():
 
         if calendar:
             events = get_events(calendar)
-            logging.info(f"Found {len(events)} events at {config['calendarUrl']}.")
+            log.info(f"Found {len(events)} events at {config['calendarUrl']}.")
 
             replica_count_overrides = get_replica_counts(events)
-            logging.info(f"Overrides: {replica_count_overrides}")
+            log.info(f"Overrides: {replica_count_overrides}")
 
             # Generate deployment config based on our config
             for pool_name, pool_config in config["nodePools"].items():
                 pool_usable_resources = usable_resources_result.get(
                     pool_config["nodeSelector"][node_selector_key], {}
                 )
-                logging.info(f"Processing the node pool: {pool_name} ... ")
+                log.info(f"Processing the node pool: {pool_name} ... ")
                 node_placeholder_deployment_reduction = 0
                 now = time.perf_counter()
                 for node, resources in pool_usable_resources.items():
-                    logging.info(f"Checking node {node} in pool {pool_name} ...")
-                    logging.info(
+                    log.info(f"Checking node {node} in pool {pool_name} ...")
+                    log.info(
                         f"Node {node} has {resources['cpu_free_ratio']:.2f} CPU free ratio and {resources['mem_free_ratio']:.2f} Memory free ratio."
                     )
                     # Check if a placeholder pod is running on this node
@@ -431,11 +427,11 @@ def main():
                         update_node_last_above_threshold(
                             node, node_last_above_threshold, now
                         )
-                        logging.info(
+                        log.info(
                             f"Placeholder pod is running on {node}. Skipping resource check for this node."
                         )
                     elif unschedulable_node:
-                        logging.info(
+                        log.info(
                             f"Node {node} is unschedulable. Skipping resource check for this node."
                         )
                     else:
@@ -460,7 +456,7 @@ def main():
                                 node, node_last_above_threshold, now
                             )
                         elif node_age_seconds < node_grace_period:
-                            logging.info(
+                            log.info(
                                 f"Node {node} has been observed for {node_age_seconds:.0f}s, "
                                 f"within {node_grace_period}s grace period. Skipping reduction."
                             )
@@ -470,12 +466,12 @@ def main():
                             < node_grace_period
                         ):
                             time_since_freed = now - node_last_above_threshold[node]
-                            logging.info(
+                            log.info(
                                 f"Node {node} was above threshold {time_since_freed:.0f}s ago, "
                                 f"within {node_grace_period}s recently-freed grace period. Skipping reduction."
                             )
                         else:
-                            logging.info(
+                            log.info(
                                 f"Node {node} has sufficient resources (Strategy: {strategy}, CPU free ratio: {cpu_free_ratio:.2f}, Memory free ratio: {mem_free_ratio:.2f})."
                             )
                             node_placeholder_deployment_reduction += 1
@@ -494,25 +490,25 @@ def main():
                 has_pending_placeholder = any_placeholder_pod_pending(
                     namespace, label_selector, pool_config["nodeSelector"]
                 )
-                logging.info(
+                log.info(
                     f"Calendar replica count for pool {pool_name}: {calendar_replica_count}"
                 )
-                logging.info(
+                log.info(
                     f"Config replica count for pool {pool_name}: {config_replica_count}"
                 )
-                logging.info(
+                log.info(
                     f"Pending placeholder pod detected for pool {pool_name}: {has_pending_placeholder}"
                 )
                 if calendar_replica_count > 0 and calendar_override_enabled:
-                    logging.info(
+                    log.info(
                         f"Overriding replica count for pool {pool_name} with calendar replica count {calendar_replica_count} instead of modified replica count {modified_replica}."
                     )
                 elif has_pending_placeholder:
-                    logging.info(
+                    log.info(
                         f"Suppressing reduction for pool {pool_name}: placeholder pod is Pending."
                     )
                 else:
-                    logging.info(
+                    log.info(
                         f"Reducing {pool_name} placeholder deployment replicas by {node_placeholder_deployment_reduction} based on node resources."
                     )
                 replica_count = compute_replica_count(
@@ -522,9 +518,7 @@ def main():
                     calendar_override_enabled,
                     has_pending_placeholder,
                 )
-                logging.info(
-                    f"Final replica count for pool {pool_name}: {replica_count}"
-                )
+                log.info(f"Final replica count for pool {pool_name}: {replica_count}")
 
                 deployment = make_deployment(
                     pool_name,
@@ -533,7 +527,7 @@ def main():
                     pool_config["resources"],
                     replica_count,
                 )
-                logging.info(f"Setting {pool_name} to have {replica_count} replicas")
+                log.info(f"Setting {pool_name} to have {replica_count} replicas")
                 with tempfile.NamedTemporaryFile(mode="r+") as f:
                     yaml.dump(deployment, f)
                     f.flush()
@@ -544,7 +538,7 @@ def main():
                         text=True,
                     )
 
-                    logging.info(proc.stdout.strip())
+                    log.info(proc.stdout.strip())
 
         # Evict tracking entries for nodes no longer present in the cluster.
         all_seen_nodes = {

--- a/node-placeholder-scaler/scaler/scaler.py
+++ b/node-placeholder-scaler/scaler/scaler.py
@@ -273,6 +273,17 @@ def make_deployment(pool_name, template, node_selector, resources, replicas):
 log = logging.getLogger(__name__)
 
 
+def update_node_first_seen(node: str, node_first_seen: dict, now: float) -> float:
+    """Record the first time a node is observed and return its observed age in seconds.
+
+    Uses perf_counter values so the age is relative to scaler uptime, not wall
+    clock time.  Mutates node_first_seen in place.
+    """
+    if node not in node_first_seen:
+        node_first_seen[node] = now
+    return now - node_first_seen[node]
+
+
 def get_replica_counts(events):
     replica_counts = {}
     for ev in events:
@@ -330,6 +341,12 @@ def main():
     argparser.add_argument(
         "--strategy", choices=["cpu", "mem", "balanced"], default="balanced"
     )
+    argparser.add_argument(
+        "--node-grace-period",
+        type=int,
+        default=300,
+        help="Seconds after node creation during which the node is excluded from placeholder reduction.",
+    )
 
     args = argparser.parse_args()
 
@@ -339,6 +356,11 @@ def main():
     cpu_threshold = args.cpu_threshold
     memory_threshold = args.memory_threshold
     strategy = args.strategy
+    node_grace_period = args.node_grace_period
+
+    # Maps node name -> perf_counter value when the scaler first observed it.
+    # Used to enforce the node grace period across loop iterations.
+    node_first_seen: dict[str, float] = {}
 
     while True:
         usable_resources_result = get_usable_resources()
@@ -366,6 +388,7 @@ def main():
                 )
                 logging.info(f"Processing the node pool: {pool_name} ... ")
                 node_placeholder_deployment_reduction = 0
+                now = time.perf_counter()
                 for node, resources in pool_usable_resources.items():
                     logging.info(f"Checking node {node} in pool {pool_name} ...")
                     logging.info(
@@ -378,23 +401,35 @@ def main():
                     # Check if the node is unschedulable
                     unschedulable_node = is_unschedulable_node(node)
                     if not placeholder_pod_running and not unschedulable_node:
-                        cpu_free_ratio = resources["cpu_free_ratio"]
-                        mem_free_ratio = resources["mem_free_ratio"]
-                        if (
-                            (strategy == "cpu" and cpu_free_ratio > cpu_threshold)
-                            or (strategy == "mem" and mem_free_ratio > memory_threshold)
-                            or (
-                                strategy == "balanced"
-                                and (
-                                    cpu_free_ratio > cpu_threshold
+                        node_age_seconds = update_node_first_seen(
+                            node, node_first_seen, now
+                        )
+                        if node_age_seconds < node_grace_period:
+                            logging.info(
+                                f"Node {node} has been observed for {node_age_seconds:.0f}s, "
+                                f"within {node_grace_period}s grace period. Skipping reduction."
+                            )
+                        else:
+                            cpu_free_ratio = resources["cpu_free_ratio"]
+                            mem_free_ratio = resources["mem_free_ratio"]
+                            if (
+                                (strategy == "cpu" and cpu_free_ratio > cpu_threshold)
+                                or (
+                                    strategy == "mem"
                                     and mem_free_ratio > memory_threshold
                                 )
-                            )
-                        ):
-                            logging.info(
-                                f"Node {node} has sufficient resources (Strategy: {strategy}, CPU free ratio: {cpu_free_ratio:.2f}, Memory free ratio: {mem_free_ratio:.2f})."
-                            )
-                            node_placeholder_deployment_reduction += 1
+                                or (
+                                    strategy == "balanced"
+                                    and (
+                                        cpu_free_ratio > cpu_threshold
+                                        and mem_free_ratio > memory_threshold
+                                    )
+                                )
+                            ):
+                                logging.info(
+                                    f"Node {node} has sufficient resources (Strategy: {strategy}, CPU free ratio: {cpu_free_ratio:.2f}, Memory free ratio: {mem_free_ratio:.2f})."
+                                )
+                                node_placeholder_deployment_reduction += 1
                     else:
                         if placeholder_pod_running:
                             logging.info(
@@ -470,4 +505,14 @@ def main():
                     )
 
                     logging.info(proc.stdout.strip())
+
+        # Evict first-seen entries for nodes no longer present in the cluster.
+        all_seen_nodes = {
+            node
+            for pool_nodes in usable_resources_result.values()
+            for node in pool_nodes
+        }
+        node_first_seen = {
+            n: t for n, t in node_first_seen.items() if n in all_seen_nodes
+        }
         time.sleep(60)

--- a/node-placeholder-scaler/scaler/scaler.py
+++ b/node-placeholder-scaler/scaler/scaler.py
@@ -501,41 +501,49 @@ def main():
         with open(args.placeholder_template_file) as f:
             placeholder_template = yaml.load(f)
 
-        calendar = get_calendar(cfg["calendarUrl"])
+        if "calendarUrl" in cfg:
+            calendar = get_calendar(cfg["calendarUrl"])
+        else:
+            log.info(
+                "No calendarUrl in config; skipping calendar processing and using config replica counts only."
+            )
+            calendar = None
 
         if calendar:
             events = get_events(calendar)
             log.info(f"Found {len(events)} events at {cfg['calendarUrl']}.")
-
             replica_count_overrides = get_replica_counts(events)
             log.info(f"Overrides: {replica_count_overrides}")
+        else:
+            log.info("No calendar available; using config replica counts only.")
+            replica_count_overrides = {}
 
-            calendar_override_enabled = cfg.get("calendarOverrideEnabled", False)
-            if not isinstance(calendar_override_enabled, bool):
-                raise ValueError(
-                    f"calendarOverrideEnabled must be a boolean, got {type(calendar_override_enabled).__name__}: {calendar_override_enabled!r}"
-                )
+        calendar_override_enabled = cfg.get("calendarOverrideEnabled", False)
+        if not isinstance(calendar_override_enabled, bool):
+            raise ValueError(
+                f"calendarOverrideEnabled must be a boolean, got {type(calendar_override_enabled).__name__}: {calendar_override_enabled!r}"
+            )
 
-            for pool_name, pool_config in cfg["nodePools"].items():
-                pool_usable_resources = usable_resources_result.get(
-                    pool_config["nodeSelector"][node_selector_key], {}
-                )
-                _process_pool(
-                    pool_name=pool_name,
-                    pool_config=pool_config,
-                    pool_usable_resources=pool_usable_resources,
-                    replica_count_overrides=replica_count_overrides,
-                    calendar_override_enabled=calendar_override_enabled,
-                    placeholder_template=placeholder_template,
-                    namespace=namespace,
-                    label_selector=label_selector,
-                    strategy=strategy,
-                    cpu_threshold=cpu_threshold,
-                    memory_threshold=memory_threshold,
-                    node_grace_period=node_grace_period,
-                    node_first_seen=node_first_seen,
-                    node_last_above_threshold=node_last_above_threshold,
-                )
+        for pool_name, pool_config in cfg["nodePools"].items():
+            pool_usable_resources = usable_resources_result.get(
+                pool_config["nodeSelector"][node_selector_key], {}
+            )
+            _process_pool(
+                pool_name=pool_name,
+                pool_config=pool_config,
+                pool_usable_resources=pool_usable_resources,
+                replica_count_overrides=replica_count_overrides,
+                calendar_override_enabled=calendar_override_enabled,
+                placeholder_template=placeholder_template,
+                namespace=namespace,
+                label_selector=label_selector,
+                strategy=strategy,
+                cpu_threshold=cpu_threshold,
+                memory_threshold=memory_threshold,
+                node_grace_period=node_grace_period,
+                node_first_seen=node_first_seen,
+                node_last_above_threshold=node_last_above_threshold,
+            )
 
         # Evict tracking entries for nodes no longer present in the cluster.
         all_seen_nodes = {

--- a/node-placeholder-scaler/tests/test_calendar_parser.py
+++ b/node-placeholder-scaler/tests/test_calendar_parser.py
@@ -83,6 +83,16 @@ ICS_ALL_DAY = _vcal(
     "END:VEVENT"
 )
 
+# Event with no DESCRIPTION field
+ICS_NO_DESC = _vcal(
+    "BEGIN:VEVENT\n"
+    "UID:ev-nodesc@test\n"
+    "DTSTART:20230427T170000Z\n"
+    "DTEND:20230427T180000Z\n"
+    "SUMMARY:No Description Event\n"
+    "END:VEVENT"
+)
+
 # No events at all
 ICS_EMPTY = _vcal()
 
@@ -361,6 +371,12 @@ class TestGetEvents:
         t = datetime.datetime(2023, 4, 29, 12, 0, tzinfo=UTC)
         events = get_events(cal, time=t)
         assert len(events) == 0
+
+    def test_event_with_no_description_does_not_crash(self):
+        cal = self._cal(ICS_NO_DESC)
+        t = datetime.datetime(2023, 4, 27, 17, 30, tzinfo=UTC)
+        events = get_events(cal, time=t)
+        assert len(events) == 1
 
     def test_returns_list_not_generator(self):
         """get_events must return a list, not a generator or iterator."""

--- a/node-placeholder-scaler/tests/test_scaler.py
+++ b/node-placeholder-scaler/tests/test_scaler.py
@@ -954,16 +954,21 @@ class TestUpdateNodeFirstSeen:
         assert node_first_seen["node-a"] == 600.0
 
     def test_age_within_grace_period(self):
-        """Node first seen 100s ago is within a 300s grace period."""
-        node_first_seen = {"node-a": 900.0}
-        age = update_node_first_seen("node-a", node_first_seen, now=1000.0)
-        assert age < 300
+        """A node seen 100s ago is within a 600s grace period."""
+        now = 1000.0
+        # stored value is the clock reading when first seen, so 100s of age
+        # means first_seen = now - 100.
+        node_first_seen = {"node-a": now - 100}
+        age = update_node_first_seen("node-a", node_first_seen, now=now)
+        assert age < 600
 
     def test_age_exceeds_grace_period(self):
-        """Node first seen 400s ago exceeds a 300s grace period."""
-        node_first_seen = {"node-a": 600.0}
-        age = update_node_first_seen("node-a", node_first_seen, now=1000.0)
-        assert age >= 300
+        """A node seen 700s ago exceeds a 600s grace period."""
+        now = 1000.0
+        # first_seen = now - 700 => age of 700s, past the 600s threshold.
+        node_first_seen = {"node-a": now - 700}
+        age = update_node_first_seen("node-a", node_first_seen, now=now)
+        assert age >= 600
 
     def test_multiple_nodes_tracked_independently(self):
         """Each node has its own first-seen timestamp."""
@@ -1009,16 +1014,21 @@ class TestUpdateNodeLastAboveThreshold:
         assert d["node-a"] == 500.0
 
     def test_recently_freed_within_grace_period(self):
-        """A node last above threshold 100s ago is within a 300s grace period."""
-        d = {"node-a": 900.0}
-        time_since = 1000.0 - d["node-a"]
-        assert time_since < 300
+        """A node last above threshold 100s ago is within a 600s grace period."""
+        now = 1000.0
+        # stored value is the clock reading when last above threshold, so
+        # 100s of elapsed time means last_above = now - 100.
+        d = {"node-a": now - 100}
+        time_since = now - d["node-a"]
+        assert time_since < 600
 
     def test_recently_freed_exceeds_grace_period(self):
-        """A node last above threshold 400s ago exceeds the 300s grace period."""
-        d = {"node-a": 600.0}
-        time_since = 1000.0 - d["node-a"]
-        assert time_since >= 300
+        """A node last above threshold 700s ago exceeds the 600s grace period."""
+        now = 1000.0
+        # last_above = now - 700 => 700s elapsed, past the 600s threshold.
+        d = {"node-a": now - 700}
+        time_since = now - d["node-a"]
+        assert time_since >= 600
 
     def test_node_never_above_threshold_not_in_dict(self):
         """A node with no above-threshold history has no entry in the dict."""

--- a/node-placeholder-scaler/tests/test_scaler.py
+++ b/node-placeholder-scaler/tests/test_scaler.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock, patch
 from kubernetes.client.exceptions import ApiException
 from kubernetes.config import ConfigException
 from scaler.scaler import (
+    any_placeholder_pod_pending,
+    compute_replica_count,
     get_allocatable_resources_by_pool,
     get_node_pool_mapping,
     get_replica_counts,
@@ -690,3 +692,113 @@ class TestIsUnschedulableNode:
         mock_api_cls.return_value.read_node.assert_called_once_with(
             name="my-special-node"
         )
+
+
+# ---------------------------------------------------------------------------
+# any_placeholder_pod_pending
+# ---------------------------------------------------------------------------
+
+_NODE_SELECTOR = {"hub.jupyter.org/pool-name": "pool-a"}
+_OTHER_NODE_SELECTOR = {"hub.jupyter.org/pool-name": "pool-b"}
+
+
+def _pending_pod(node_selector=None):
+    p = MagicMock()
+    p.status.phase = "Pending"
+    p.spec.node_selector = node_selector or _NODE_SELECTOR
+    return p
+
+
+class TestAnyPlaceholderPodPending:
+    @patch("scaler.scaler.config.load_kube_config")
+    @patch("scaler.scaler.config.load_incluster_config")
+    @patch("scaler.scaler.client.CoreV1Api")
+    def test_no_pods_returns_false(self, mock_api_cls, mock_incluster, mock_kube):
+        mock_incluster.side_effect = ConfigException()
+        mock_api_cls.return_value.list_namespaced_pod.return_value.items = []
+        assert any_placeholder_pod_pending("ns", "app=ph", _NODE_SELECTOR) is False
+
+    @patch("scaler.scaler.config.load_kube_config")
+    @patch("scaler.scaler.config.load_incluster_config")
+    @patch("scaler.scaler.client.CoreV1Api")
+    def test_running_pod_returns_false(self, mock_api_cls, mock_incluster, mock_kube):
+        mock_incluster.side_effect = ConfigException()
+        p = MagicMock()
+        p.status.phase = "Running"
+        p.spec.node_selector = _NODE_SELECTOR
+        mock_api_cls.return_value.list_namespaced_pod.return_value.items = [p]
+        assert any_placeholder_pod_pending("ns", "app=ph", _NODE_SELECTOR) is False
+
+    @patch("scaler.scaler.config.load_kube_config")
+    @patch("scaler.scaler.config.load_incluster_config")
+    @patch("scaler.scaler.client.CoreV1Api")
+    def test_pending_pod_matching_pool_returns_true(
+        self, mock_api_cls, mock_incluster, mock_kube
+    ):
+        mock_incluster.side_effect = ConfigException()
+        mock_api_cls.return_value.list_namespaced_pod.return_value.items = [
+            _pending_pod(_NODE_SELECTOR)
+        ]
+        assert any_placeholder_pod_pending("ns", "app=ph", _NODE_SELECTOR) is True
+
+    @patch("scaler.scaler.config.load_kube_config")
+    @patch("scaler.scaler.config.load_incluster_config")
+    @patch("scaler.scaler.client.CoreV1Api")
+    def test_pending_pod_different_pool_returns_false(
+        self, mock_api_cls, mock_incluster, mock_kube
+    ):
+        """Pending pod from a different pool must not suppress reduction for this pool."""
+        mock_incluster.side_effect = ConfigException()
+        mock_api_cls.return_value.list_namespaced_pod.return_value.items = [
+            _pending_pod(_OTHER_NODE_SELECTOR)
+        ]
+        assert any_placeholder_pod_pending("ns", "app=ph", _NODE_SELECTOR) is False
+
+    @patch("scaler.scaler.config.load_kube_config")
+    @patch("scaler.scaler.config.load_incluster_config")
+    @patch("scaler.scaler.client.CoreV1Api")
+    def test_api_error_returns_false(self, mock_api_cls, mock_incluster, mock_kube):
+        mock_incluster.side_effect = ConfigException()
+        mock_api_cls.return_value.list_namespaced_pod.side_effect = ApiException()
+        assert any_placeholder_pod_pending("ns", "app=ph", _NODE_SELECTOR) is False
+
+
+# ---------------------------------------------------------------------------
+# compute_replica_count
+# ---------------------------------------------------------------------------
+
+
+class TestComputeReplicaCount:
+    def test_normal_no_reduction(self):
+        assert compute_replica_count(1, 1, 0, False) == 1
+
+    def test_normal_with_reduction(self):
+        """When a node has spare capacity, reduction brings count to 0."""
+        assert compute_replica_count(0, 1, 0, False) == 0
+
+    def test_pending_suppresses_reduction(self):
+        """Race condition: placeholder evicted but not yet rescheduled."""
+        assert compute_replica_count(0, 1, 0, False, has_pending_placeholder=True) == 1
+
+    def test_pending_returns_config_not_modified(self):
+        """Floor is config_replica_count, not modified_replica, when pending."""
+        assert compute_replica_count(-1, 2, 0, False, has_pending_placeholder=True) == 2
+
+    def test_calendar_override_takes_priority(self):
+        assert compute_replica_count(0, 1, 3, True) == 3
+
+    def test_calendar_override_ignores_pending(self):
+        """Calendar override is authoritative; pending state doesn't change it."""
+        assert compute_replica_count(0, 1, 3, True, has_pending_placeholder=True) == 3
+
+    def test_calendar_count_zero_falls_through(self):
+        """calendar_replica_count=0 means no active calendar event; use normal path."""
+        assert compute_replica_count(1, 1, 0, True) == 1
+
+    def test_calendar_disabled_falls_through(self):
+        """calendar_override_enabled=False means ignore calendar count."""
+        assert compute_replica_count(0, 1, 3, False) == 0
+
+    def test_modified_replica_floored_at_zero(self):
+        """Without pending, result is never negative."""
+        assert compute_replica_count(-1, 1, 0, False) == 0

--- a/node-placeholder-scaler/tests/test_scaler.py
+++ b/node-placeholder-scaler/tests/test_scaler.py
@@ -904,9 +904,13 @@ class TestComputeReplicaCount:
         """Race condition: placeholder evicted but not yet rescheduled."""
         assert compute_replica_count(0, 1, 0, False, has_pending_placeholder=True) == 1
 
-    def test_pending_returns_config_not_modified(self):
-        """Floor is config_replica_count, not modified_replica, when pending."""
+    def test_pending_returns_override_not_modified(self):
+        """Floor is override_replica_count, not modified_replica, when pending."""
         assert compute_replica_count(-1, 2, 0, False, has_pending_placeholder=True) == 2
+
+    def test_pending_preserves_calendar_count_when_override_disabled(self):
+        """Calendar count survives the pending window even with override off."""
+        assert compute_replica_count(-1, 3, 3, False, has_pending_placeholder=True) == 3
 
     def test_calendar_override_takes_priority(self):
         assert compute_replica_count(0, 1, 3, True) == 3

--- a/node-placeholder-scaler/tests/test_scaler.py
+++ b/node-placeholder-scaler/tests/test_scaler.py
@@ -21,6 +21,7 @@ from scaler.scaler import (
     is_unschedulable_node,
     make_deployment,
     placeholder_pod_running_on_node,
+    update_node_first_seen,
 )
 
 # ---------------------------------------------------------------------------
@@ -924,3 +925,56 @@ class TestComputeReplicaCount:
     def test_modified_replica_floored_at_zero(self):
         """Without pending, result is never negative."""
         assert compute_replica_count(-1, 1, 0, False) == 0
+
+
+class TestUpdateNodeFirstSeen:
+    def test_new_node_age_is_zero(self):
+        """A node seen for the first time has an observed age of 0."""
+        node_first_seen = {}
+        age = update_node_first_seen("node-a", node_first_seen, now=1000.0)
+        assert age == 0.0
+
+    def test_new_node_recorded_in_dict(self):
+        node_first_seen = {}
+        update_node_first_seen("node-a", node_first_seen, now=1000.0)
+        assert "node-a" in node_first_seen
+        assert node_first_seen["node-a"] == 1000.0
+
+    def test_existing_node_age_reflects_elapsed_time(self):
+        """A node first seen 400s ago reports age 400s."""
+        node_first_seen = {"node-a": 600.0}
+        age = update_node_first_seen("node-a", node_first_seen, now=1000.0)
+        assert age == 400.0
+
+    def test_existing_node_first_seen_time_unchanged(self):
+        """Calling again with a later 'now' does not overwrite the first-seen time."""
+        node_first_seen = {"node-a": 600.0}
+        update_node_first_seen("node-a", node_first_seen, now=1000.0)
+        assert node_first_seen["node-a"] == 600.0
+
+    def test_age_within_grace_period(self):
+        """Node first seen 100s ago is within a 300s grace period."""
+        node_first_seen = {"node-a": 900.0}
+        age = update_node_first_seen("node-a", node_first_seen, now=1000.0)
+        assert age < 300
+
+    def test_age_exceeds_grace_period(self):
+        """Node first seen 400s ago exceeds a 300s grace period."""
+        node_first_seen = {"node-a": 600.0}
+        age = update_node_first_seen("node-a", node_first_seen, now=1000.0)
+        assert age >= 300
+
+    def test_multiple_nodes_tracked_independently(self):
+        """Each node has its own first-seen timestamp."""
+        node_first_seen = {"node-a": 500.0, "node-b": 800.0}
+        age_a = update_node_first_seen("node-a", node_first_seen, now=1000.0)
+        age_b = update_node_first_seen("node-b", node_first_seen, now=1000.0)
+        assert age_a == 500.0
+        assert age_b == 200.0
+
+    def test_new_node_does_not_affect_existing_entries(self):
+        """Adding a new node leaves existing entries untouched."""
+        node_first_seen = {"node-a": 500.0}
+        update_node_first_seen("node-b", node_first_seen, now=1000.0)
+        assert node_first_seen["node-a"] == 500.0
+        assert node_first_seen["node-b"] == 1000.0

--- a/node-placeholder-scaler/tests/test_scaler.py
+++ b/node-placeholder-scaler/tests/test_scaler.py
@@ -22,6 +22,7 @@ from scaler.scaler import (
     make_deployment,
     placeholder_pod_running_on_node,
     update_node_first_seen,
+    update_node_last_above_threshold,
 )
 
 # ---------------------------------------------------------------------------
@@ -978,3 +979,55 @@ class TestUpdateNodeFirstSeen:
         update_node_first_seen("node-b", node_first_seen, now=1000.0)
         assert node_first_seen["node-a"] == 500.0
         assert node_first_seen["node-b"] == 1000.0
+
+
+class TestUpdateNodeLastAboveThreshold:
+    def test_new_node_is_recorded(self):
+        """First call records the node with the given timestamp."""
+        d = {}
+        update_node_last_above_threshold("node-a", d, now=1000.0)
+        assert d["node-a"] == 1000.0
+
+    def test_existing_node_timestamp_is_updated(self):
+        """Subsequent calls overwrite the previous timestamp."""
+        d = {"node-a": 500.0}
+        update_node_last_above_threshold("node-a", d, now=1000.0)
+        assert d["node-a"] == 1000.0
+
+    def test_multiple_nodes_tracked_independently(self):
+        """Each node maintains its own last-above-threshold time."""
+        d = {}
+        update_node_last_above_threshold("node-a", d, now=800.0)
+        update_node_last_above_threshold("node-b", d, now=1000.0)
+        assert d["node-a"] == 800.0
+        assert d["node-b"] == 1000.0
+
+    def test_update_does_not_affect_other_entries(self):
+        """Updating one node leaves other entries untouched."""
+        d = {"node-a": 500.0}
+        update_node_last_above_threshold("node-b", d, now=1000.0)
+        assert d["node-a"] == 500.0
+
+    def test_recently_freed_within_grace_period(self):
+        """A node last above threshold 100s ago is within a 300s grace period."""
+        d = {"node-a": 900.0}
+        time_since = 1000.0 - d["node-a"]
+        assert time_since < 300
+
+    def test_recently_freed_exceeds_grace_period(self):
+        """A node last above threshold 400s ago exceeds the 300s grace period."""
+        d = {"node-a": 600.0}
+        time_since = 1000.0 - d["node-a"]
+        assert time_since >= 300
+
+    def test_node_never_above_threshold_not_in_dict(self):
+        """A node with no above-threshold history has no entry in the dict."""
+        d = {}
+        assert "node-a" not in d
+
+    def test_repeated_updates_reflect_latest_time(self):
+        """Calling multiple times always stores the most recent timestamp."""
+        d = {}
+        for t in [100.0, 500.0, 900.0, 1000.0]:
+            update_node_last_above_threshold("node-a", d, now=t)
+        assert d["node-a"] == 1000.0

--- a/node-placeholder-scaler/tests/test_scaler.py
+++ b/node-placeholder-scaler/tests/test_scaler.py
@@ -165,6 +165,15 @@ class TestGetReplicaCounts:
         ev = _event("pool-a: not-a-number\n")
         assert get_replica_counts([ev]) == {}
 
+    def test_negative_value_skipped(self):
+        ev = _event("pool-a: -1\n")
+        assert get_replica_counts([ev]) == {}
+
+    def test_zero_value_preserved(self):
+        """An explicit 0 is a real count, not an absent pool."""
+        ev = _event("pool-a: 0\n")
+        assert get_replica_counts([ev]) == {"pool-a": 0}
+
     def test_mixed_valid_and_invalid(self):
         ev = _event("pool-a: 5\npool-b: bad\n")
         result = get_replica_counts([ev])
@@ -185,18 +194,6 @@ class TestGetReplicaCounts:
         ev2 = _event("pool-b: 5\npool-c: 2\n")
         result = get_replica_counts([ev1, ev2])
         assert result == {"pool-a": 3, "pool-b": 5, "pool-c": 2}
-
-    def test_negative_count_accepted(self):
-        """Negative counts are stored as-is; compute_replica_count floors the result at 0."""
-        ev = _event("pool-a: -1\n")
-        assert get_replica_counts([ev]) == {"pool-a": -1}
-
-    def test_zero_count_stored_but_not_used_as_override(self):
-        """Zero is a valid integer and is stored, but compute_replica_count treats
-        calendar_replica_count=0 as 'no active event' and falls through to normal scaling.
-        """
-        ev = _event("pool-a: 0\n")
-        assert get_replica_counts([ev]) == {"pool-a": 0}
 
 
 # ---------------------------------------------------------------------------
@@ -894,19 +891,23 @@ class TestAnyPlaceholderPodPending:
 
 class TestComputeReplicaCount:
     def test_normal_no_reduction(self):
-        assert compute_replica_count(1, 1, 0, False) == 1
+        assert compute_replica_count(1, 1, None, False) == 1
 
     def test_normal_with_reduction(self):
         """When a node has spare capacity, reduction brings count to 0."""
-        assert compute_replica_count(0, 1, 0, False) == 0
+        assert compute_replica_count(0, 1, None, False) == 0
 
     def test_pending_suppresses_reduction(self):
         """Race condition: placeholder evicted but not yet rescheduled."""
-        assert compute_replica_count(0, 1, 0, False, has_pending_placeholder=True) == 1
+        assert (
+            compute_replica_count(0, 1, None, False, has_pending_placeholder=True) == 1
+        )
 
     def test_pending_returns_override_not_modified(self):
         """Floor is override_replica_count, not modified_replica, when pending."""
-        assert compute_replica_count(-1, 2, 0, False, has_pending_placeholder=True) == 2
+        assert (
+            compute_replica_count(-1, 2, None, False, has_pending_placeholder=True) == 2
+        )
 
     def test_pending_preserves_calendar_count_when_override_disabled(self):
         """Calendar count survives the pending window even with override off."""
@@ -919,9 +920,13 @@ class TestComputeReplicaCount:
         """Calendar override is authoritative; pending state doesn't change it."""
         assert compute_replica_count(0, 1, 3, True, has_pending_placeholder=True) == 3
 
-    def test_calendar_count_zero_falls_through(self):
-        """calendar_replica_count=0 means no active calendar event; use normal path."""
-        assert compute_replica_count(1, 1, 0, True) == 1
+    def test_calendar_count_none_falls_through(self):
+        """calendar_replica_count=None means no active calendar event; use normal path."""
+        assert compute_replica_count(1, 1, None, True) == 1
+
+    def test_calendar_count_zero_is_honored(self):
+        """An event explicitly setting 0 is authoritative, not treated as absent."""
+        assert compute_replica_count(1, 1, 0, True) == 0
 
     def test_calendar_disabled_falls_through(self):
         """calendar_override_enabled=False means ignore calendar count."""
@@ -929,7 +934,7 @@ class TestComputeReplicaCount:
 
     def test_modified_replica_floored_at_zero(self):
         """Without pending, result is never negative."""
-        assert compute_replica_count(-1, 1, 0, False) == 0
+        assert compute_replica_count(-1, 1, None, False) == 0
 
 
 class TestUpdateNodeFirstSeen:

--- a/node-placeholder-scaler/tests/test_scaler.py
+++ b/node-placeholder-scaler/tests/test_scaler.py
@@ -184,6 +184,18 @@ class TestGetReplicaCounts:
         result = get_replica_counts([ev1, ev2])
         assert result == {"pool-a": 3, "pool-b": 5, "pool-c": 2}
 
+    def test_negative_count_accepted(self):
+        """Negative counts are stored as-is; compute_replica_count floors the result at 0."""
+        ev = _event("pool-a: -1\n")
+        assert get_replica_counts([ev]) == {"pool-a": -1}
+
+    def test_zero_count_stored_but_not_used_as_override(self):
+        """Zero is a valid integer and is stored, but compute_replica_count treats
+        calendar_replica_count=0 as 'no active event' and falls through to normal scaling.
+        """
+        ev = _event("pool-a: 0\n")
+        assert get_replica_counts([ev]) == {"pool-a": 0}
+
 
 # ---------------------------------------------------------------------------
 # get_node_pool_mapping
@@ -355,6 +367,19 @@ class TestGetAllocatableResourcesByPool:
             {"node-1": "pool-a", "node-2": "pool-a"}
         )
         assert len(result["pool-a"]) == 2
+
+    @patch("scaler.scaler.config.load_kube_config")
+    @patch("scaler.scaler.config.load_incluster_config")
+    @patch("scaler.scaler.client.CoreV1Api")
+    def test_invalid_memory_defaults_to_zero(
+        self, mock_api_cls, mock_incluster, mock_kube
+    ):
+        mock_incluster.side_effect = ConfigException()
+        mock_api_cls.return_value.list_node.return_value.items = [
+            _alloc_node("node-1", "2", "bad-memory")
+        ]
+        result = get_allocatable_resources_by_pool({"node-1": "pool-a"})
+        assert result["pool-a"]["node-1"]["mem_mi"] == 0
 
 
 # ---------------------------------------------------------------------------
@@ -538,6 +563,71 @@ class TestGetUsableResources:
         result = get_usable_resources()
         assert result["pool-a"]["node-1"]["cpu_free_m"] == 1500
         assert result["pool-b"]["node-2"]["cpu_free_m"] == 6000
+
+    @patch("scaler.scaler.get_requested_resources_by_pool")
+    @patch("scaler.scaler.get_allocatable_resources_by_pool")
+    @patch("scaler.scaler.get_node_pool_mapping")
+    def test_pool_absent_from_requested(self, mock_mapping, mock_alloc, mock_req):
+        """Pool exists in alloc but has no pods — requested omits it entirely."""
+        mock_mapping.return_value = {"node-1": "pool-a"}
+        mock_alloc.return_value = {
+            "pool-a": {"node-1": {"cpu_m": 4000, "mem_mi": 8192}}
+        }
+        mock_req.return_value = {}
+
+        result = get_usable_resources()
+        node = result["pool-a"]["node-1"]
+        assert node["cpu_free_m"] == 4000
+        assert node["mem_free_mi"] == 8192
+        assert node["cpu_free_ratio"] == 1.0
+        assert node["mem_free_ratio"] == 1.0
+
+    @patch("scaler.scaler.get_requested_resources_by_pool")
+    @patch("scaler.scaler.get_allocatable_resources_by_pool")
+    @patch("scaler.scaler.get_node_pool_mapping")
+    def test_node_absent_from_requested_pool(self, mock_mapping, mock_alloc, mock_req):
+        """Pool exists in requested but this specific node has no pods."""
+        mock_mapping.return_value = {"node-1": "pool-a", "node-2": "pool-a"}
+        mock_alloc.return_value = {
+            "pool-a": {
+                "node-1": {"cpu_m": 4000, "mem_mi": 8192},
+                "node-2": {"cpu_m": 4000, "mem_mi": 8192},
+            }
+        }
+        mock_req.return_value = {"pool-a": {"node-1": {"cpu_m": 1000, "mem_mi": 2048}}}
+
+        result = get_usable_resources()
+        assert result["pool-a"]["node-1"]["cpu_free_m"] == 3000
+        assert result["pool-a"]["node-2"]["cpu_free_m"] == 4000
+        assert result["pool-a"]["node-2"]["cpu_free_ratio"] == 1.0
+
+    @patch("scaler.scaler.get_requested_resources_by_pool")
+    @patch("scaler.scaler.get_allocatable_resources_by_pool")
+    @patch("scaler.scaler.get_node_pool_mapping")
+    def test_zero_allocatable_cpu_no_division_error(
+        self, mock_mapping, mock_alloc, mock_req
+    ):
+        """cpu_m=0 (e.g. parse failure) must not raise ZeroDivisionError."""
+        mock_mapping.return_value = {"node-1": "pool-a"}
+        mock_alloc.return_value = {"pool-a": {"node-1": {"cpu_m": 0, "mem_mi": 8192}}}
+        mock_req.return_value = {"pool-a": {"node-1": {"cpu_m": 0, "mem_mi": 0}}}
+
+        result = get_usable_resources()
+        assert result["pool-a"]["node-1"]["cpu_free_ratio"] == 0.0
+
+    @patch("scaler.scaler.get_requested_resources_by_pool")
+    @patch("scaler.scaler.get_allocatable_resources_by_pool")
+    @patch("scaler.scaler.get_node_pool_mapping")
+    def test_zero_allocatable_mem_no_division_error(
+        self, mock_mapping, mock_alloc, mock_req
+    ):
+        """mem_mi=0 (e.g. parse failure) must not raise ZeroDivisionError."""
+        mock_mapping.return_value = {"node-1": "pool-a"}
+        mock_alloc.return_value = {"pool-a": {"node-1": {"cpu_m": 4000, "mem_mi": 0}}}
+        mock_req.return_value = {"pool-a": {"node-1": {"cpu_m": 0, "mem_mi": 0}}}
+
+        result = get_usable_resources()
+        assert result["pool-a"]["node-1"]["mem_free_ratio"] == 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -761,6 +851,38 @@ class TestAnyPlaceholderPodPending:
         mock_incluster.side_effect = ConfigException()
         mock_api_cls.return_value.list_namespaced_pod.side_effect = ApiException()
         assert any_placeholder_pod_pending("ns", "app=ph", _NODE_SELECTOR) is False
+
+    @patch("scaler.scaler.config.load_kube_config")
+    @patch("scaler.scaler.config.load_incluster_config")
+    @patch("scaler.scaler.client.CoreV1Api")
+    def test_namespace_and_label_selector_passed_to_api(
+        self, mock_api_cls, mock_incluster, mock_kube
+    ):
+        mock_incluster.side_effect = ConfigException()
+        mock_api_cls.return_value.list_namespaced_pod.return_value.items = []
+        any_placeholder_pod_pending(
+            "my-ns", "app=ph,component=placeholder", _NODE_SELECTOR
+        )
+        mock_api_cls.return_value.list_namespaced_pod.assert_called_once_with(
+            namespace="my-ns", label_selector="app=ph,component=placeholder"
+        )
+
+    @patch("scaler.scaler.config.load_kube_config")
+    @patch("scaler.scaler.config.load_incluster_config")
+    @patch("scaler.scaler.client.CoreV1Api")
+    def test_multiple_pods_one_pending_matching_returns_true(
+        self, mock_api_cls, mock_incluster, mock_kube
+    ):
+        """Returns True when one of several pods is Pending and matches the pool."""
+        mock_incluster.side_effect = ConfigException()
+        running = MagicMock()
+        running.status.phase = "Running"
+        running.spec.node_selector = _NODE_SELECTOR
+        mock_api_cls.return_value.list_namespaced_pod.return_value.items = [
+            running,
+            _pending_pod(_NODE_SELECTOR),
+        ]
+        assert any_placeholder_pod_pending("ns", "app=ph", _NODE_SELECTOR) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This resolves https://github.com/berkeley-dsep-infra/jupyterhub-k8s-node-placeholder/issues/25

## Summary

Three race conditions fixed in the node-placeholder scaler, plus four crash bugs found during a test coverage audit and log review.

## Race condition 1: placeholder pod eviction

When a user logs in, their pod can land on the node running the placeholder. The placeholder gets evicted, but the node's memory usage stays low while the image pulls. On the next scaler cycle, the node looks free (no placeholder, low utilization), so the scaler decrements the replica count before the placeholder reschedules. The pool is left with no warm spare.

The fix checks whether any placeholder pod for the pool is already Pending before applying the reduction. If one is pending, the reduction is suppressed for that cycle.

New functions: `compute_replica_count()` (pure, unit-testable) and `any_placeholder_pod_pending()` (per-pool filtering via `node_selector`).

## Race condition 2: node oscillation after scale-to-zero

When GKE's autoscaler cordons and drains all nodes in a pool (after a calendar-driven scale-to-zero, for example), the scaler correctly sets replicas=1 once no schedulable nodes remain. GKE then provisions new nodes for the pending placeholder. With a BALANCED location policy, GKE provisions one node per zone rather than one total. Those extra nodes look free to the scaler, which immediately counts them toward its reduction and drives replicas back to 0 before the placeholder stabilizes. The result is an indefinite cycle: cordon, scaler sets 1, GKE provisions 2, scaler reduces to 0, GKE drains, repeat.

The fix adds a per-node grace period (default 300s, tunable via `--node-grace-period`). The scaler records the first time it observes each node using `time.perf_counter()` and skips nodes younger than the grace period when computing the reduction count. Nodes that are unschedulable or already running a placeholder pod are not affected. First-seen timestamps are cleaned up when nodes leave the cluster. If the scaler pod restarts, the timestamps reset and all nodes are treated as new.

I have also set the autoscaler location policy to ANY.

First-seen tracking is in `update_node_first_seen()` so it can be tested independently without mocking the full `main()` loop.

## Race condition 3: recently-freed node triggers premature reduction

When a user logs in and their pod lands on the placeholder's node, the placeholder is evicted and rescheduled to a freshly provisioned node. If the user logs out quickly, the original node drops below the memory threshold. The scaler counts it as free and reduces replicas to zero, even though the placeholder is running fine on another node. The placeholder terminates, both nodes drain, GKE removes them, and the next user waits for a cold start.

Observed in production on June 12, 2026: a single brief login produced six placeholder pod replacement cycles and significant node churn in an otherwise idle pool.  This was confirmed via Prometheus pod phase metrics and GKE autoscaler event logs

The fix tracks when each node was last above the utilization threshold or hosting a placeholder pod, using a new `node_last_above_threshold` dict that is updated every cycle. When a node drops below threshold or loses its placeholder, it is excluded from reduction for `--node-grace-period` seconds (default 300s, same argument as race condition 2).

Tracking is in `update_node_last_above_threshold()` for independent unit testing.

## Crash bugs in `get_usable_resources`

Three bugs found during a coverage audit of the existing tests (originally written with Copilot):

1. `AttributeError` when a pool has no pods: `requested_resources.get(pool)` returned `None`, and the chained `.get(node)` call raised. This hits any freshly provisioned pool.
2. `TypeError` when a node has no pods but its pool does: the pool existed in `requested_resources` but the node did not, so `.get(node)` returned `None`.
3. `ZeroDivisionError` when allocatable CPU or memory is 0: `get_allocatable_resources_by_pool` already defaults to 0 on parse failure, so this path was reachable.

Fix: replace `.get(pool).get(node)` with `.get(pool, {}).get(node, {"cpu_m": 0, "mem_mi": 0})` and guard both ratio divisions against zero denominators.

## Crash bug in `calendar_parser.get_events`

`get_events()` strips HTML from event descriptions by calling `re.sub()` on `ev.description`. Some calendar events have no description field, so `ev.description` is `None`. Passing `None` to `re.sub()` raises a `TypeError` and kills the scaler pod. The crash shows up in `kubectl logs --previous` on the running pod.

The fix skips HTML stripping when `ev.description` is `None`.

## Calendar count of zero was indistinguishable from no calendar event

The scaler read the calendar override with `replica_count_overrides.get(pool_name, 0)` and then gated on `if calendar_replica_count > 0`. Those two lines collapse two different situations into the same value. A pool with no calendar event at all got `0`, and a pool with an event that deliberately sets the count to `0` also got `0`. Neither could pass a `> 0` gate, so an explicit zero from the calendar never took the calendar branch. It fell through to the node-reduction path instead.

This has not caused a visible incident, because the fallthrough path happened to arrive at zero anyway in the cases we were running. The behavior was right by coincidence, not by construction, and it was one config change away from being wrong.

It matters more now that Berkeley treats the calendar as the canonical source for replica counts rather than the config. An event that sets a pool to zero is a deliberate instruction and needs to beat the config value the same way any other count does. cal-icor has the concrete version of this: an evening cool-off window that sets `base: 0` from 7pm to 7am. That is a real instruction to run no warm placeholder overnight, and it should not have to depend on the reduction logic reaching the same answer on its own.

The fix separates presence from value. The default is now `None`:

```python
calendar_replica_count = replica_count_overrides.get(pool_name, None)
```

and both the branch in `compute_replica_count` and the matching log line in `_process_pool` gate on `is not None`. `None` means no event covers this pool right now. Any integer, zero included, is something the calendar actually said, and it wins when `calendar_override_enabled` is set.

`>= 0` would also have separated the two cases, but only as long as nothing negative can reach the gate. The calendar branch returns its value directly with no `max(..., 0)` floor, so a typo like `base: -1` in an event description would have been passed straight through as a replica count. Rather than defend against that at the gate, `get_replica_counts` now rejects it at the point of parsing:

```python
if count < 0:
    log.error(f"Count {count} for pool {pool_name} is negative; skipping.")
    continue
```

The overrides dict is therefore guaranteed to hold non-negative integers, which is what lets the sentinel be about presence instead of sign.

The logs read better as a side effect. `Calendar replica count for pool base: None` says plainly that no event applies. A sentinel of `-1` would have printed a number that looks like a count and means the opposite.

Tests updated for the new contract: `get_replica_counts` now has coverage for a negative count being skipped and for an explicit `0` being stored rather than discarded, and the `compute_replica_count` cases that previously passed `0` to mean "no event" pass `None`.

## Logging fixes

- Restored the calendar override log message that was silently dropped in the original control flow.
- Converted an ambiguous `if/if/return` block to `if/elif/else` so the log message matches the branch actually taken.
- Split a misleading "placeholder pod is running OR node is unschedulable" log into two separate messages.

## Tests

126 total (up from 98). New tests cover: pending placeholder detection, crash paths in `get_usable_resources`, calendar override edge cases (an explicit count of 0 is honored, negative counts are rejected), `compute_replica_count` priority logic, `update_node_first_seen`, `update_node_last_above_threshold`, and `get_events` with a no-description event.

