### PR TITLE
bump vulnerable dependencies to patched versions

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 pip-tools==7.5.1
 pre-commit==4.0.1
-pytest==8.4.2
+pytest==9.0.3

--- a/node-placeholder-scaler/requirements.in
+++ b/node-placeholder-scaler/requirements.in
@@ -5,4 +5,4 @@ kubernetes==35.0.0
 niquests==3.7.2
 pyasn1==0.6.3
 ruamel.yaml
-urllib3==2.6.3
+urllib3==2.7.0

--- a/node-placeholder-scaler/requirements.txt
+++ b/node-placeholder-scaler/requirements.txt
@@ -25,7 +25,7 @@ h11==0.16.0
     # via urllib3-future
 ical==5.0.0
     # via -r requirements.in
-idna==3.11
+idna==3.16
     # via
     #   niquests
     #   requests
@@ -57,7 +57,7 @@ pyyaml==6.0.3
     # via kubernetes
 qh3==1.6.0
     # via urllib3-future
-requests==2.32.5
+requests==2.34.2
     # via
     #   kubernetes
     #   requests-oauthlib
@@ -78,7 +78,7 @@ typing-inspection==0.4.2
     # via pydantic
 tzdata==2025.3
     # via ical
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements.in
     #   kubernetes


### PR DESCRIPTION
## Summary

Addresses 5 open Dependabot security alerts:

| Package | From | To | Severity | CVE/Issue |
|---|---|---|---|---|
| urllib3 | 2.6.3 | 2.7.0 | High | Sensitive headers forwarded on redirect; decompression-bomb bypass |
| idna | 3.11 | 3.16 | Medium | Bypass of CVE-2024-3651 fix in idna.encode() |
| requests | 2.32.5 | 2.34.2 | Medium | Insecure temp file reuse in extract_zipped_paths() |
| pytest | 8.4.2 | 9.0.3 | Medium | Vulnerable tmpdir handling |

`urllib3` is pinned directly in `requirements.in`; `idna` and `requests` are transitive deps recompiled via `pip-compile`. `pytest` is updated in `dev-requirements.txt`.

Note: a chartpress rebuild and push will be needed after this merges to update the Docker image and the chart files in cal-icor-hubs.

## Test plan

- [x] All 53 existing tests pass with updated deps

Generated with [Claude Code](https://claude.ai/claude-code)